### PR TITLE
Require Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6.3.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Asynchronous library to control devices by Evil Genius Labs
 
-Requires Python 3.9+ and uses asyncio and aiohttp.
+Requires Python 3.10+ and uses asyncio and aiohttp.
 
 ```python
 import asyncio

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=["pyevilgenius"],
     zip_safe=True,
     platforms="any",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=list(val.strip() for val in open("requirements.txt")),
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
- Python 3.9 was end of life in October 2025.